### PR TITLE
Clearly demonstrate array merge behavior

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -540,3 +540,20 @@ test('deep clone', function (t) {
   t.end();
 });
 
+test('deep clone; arrays are merged', function(t) {
+  var defaults = {
+    arr: [1, 2, 3]
+  };
+  var override = {
+    arr: ["x"]
+  };
+  var expectedTarget = {
+    arr: ["x", 2, 3]
+  };
+
+  var target = extend(true, defaults, override);
+
+  t.deepEqual(target, expectedTarget, 'arrays are merged');
+  t.end();
+});
+


### PR DESCRIPTION
Current tests are slightly misleading because each test uses arrays of
the same length. Thus, the behavior of extend when merging arrays of
different lengths is not tested (nor demonstrated).

Added a test case (no code change) where the merged arrays are of
different lengths, thus creating a result array whose values come from
both source arrays.
