### PR TITLE
Fix tiny typo in "license" declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
       "iphone/6.0..latest"
     ]
   },
-  "license": "(MIT OR GPL)"
+  "license": "(MIT OR GPL-2.0)"
 }


### PR DESCRIPTION
Thanks so much for jumping right on the new SPDX license metadata guidelines!

Alas, the identifier "GPL" is actually ambiguous, since there are a few version of the GPL. I see from the README that version 2.0 is the intended license. This tiny PR makes that clear with `GPL-2.0` in lieu of just `GPL`.

I know, I know. Lamest PR ever. I'm sorry. But we can put it behind us...

Sincerest thanks for tending to node.extend!